### PR TITLE
Optimize CV for Senior SWE Roles: Reorder Sections, Enhance Project Descriptions, Add Lecturer Role, Highlight Management & Funding, Fix Formatting

### DIFF
--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -1,0 +1,61 @@
+name: Build CV PDFs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # needed for the `pdfs` branch publish step
+    steps:
+      - uses: actions/checkout@v4
+
+      # main.tex uses \usepackage{fontspec} + Source Sans Pro, which requires
+      # lualatex (or xelatex). The one-pager only needs pdflatex but we run
+      # both with lualatex for consistency.
+      - name: Build full CV (main.tex)
+        uses: xu-cheng/latex-action@v3
+        with:
+          root_file: main.tex
+          latexmk_use_lualatex: true
+          extra_system_packages: "fonts-sourcecodepro fonts-sourcesanspro"
+
+      - name: Build one-page resume
+        uses: xu-cheng/latex-action@v3
+        with:
+          root_file: one-page-resume.tex
+          latexmk_use_lualatex: true
+
+      - name: Upload PDFs as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cv-pdfs
+          path: |
+            main.pdf
+            one-page-resume.pdf
+          if-no-files-found: error
+          retention-days: 90
+
+      # On pushes to main, also publish the latest PDFs to a `pdfs` branch so
+      # you always have a stable URL (raw.githubusercontent.com/.../pdfs/...).
+      # Remove this step if you don't want auto-published builds.
+      - name: Stage PDFs for publish
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          mkdir -p _publish
+          cp main.pdf one-page-resume.pdf _publish/
+
+      - name: Publish PDFs to `pdfs` branch
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: pdfs
+          publish_dir: ./_publish
+          keep_files: false
+          commit_message: "Build PDFs from ${{ github.sha }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# LaTeX build artifacts
+*.aux
+*.bbl
+*.bcf
+*.blg
+*.fdb_latexmk
+*.fls
+*.lof
+*.log
+*.lot
+*.out
+*.run.xml
+*.synctex.gz
+*.toc
+*.xdv
+
+# Generated PDFs (built by CI; uncomment to keep PDFs out of git entirely)
+# main.pdf
+# one-page-resume.pdf
+
+# Editor / OS noise
+.DS_Store
+.vscode/

--- a/one-page-resume.tex
+++ b/one-page-resume.tex
@@ -1,22 +1,20 @@
-%% ModernCV template for Michael Ball
+%% ModernCV one-page resume for Michael Ball
 \documentclass[11pt,letter,sans]{moderncv}
 
 % moderncv themes
-\moderncvstyle{casual} 
-% \moderncvstyle{banking} 
+\moderncvstyle{casual}
 % style options: 'casual', 'classic', 'banking', 'oldstyle' and 'fancy'
 
-\definecolor{color0}{rgb}{0,0,0}
-% headings -  berkeley blue
-\definecolor{color1}{rgb}{0.0,0.15,0.46}
-% headings -  berkeley blue -- brighter 2024
-% \definecolor{color1}{rgb}{0.0,0.07,0.54}
-% accents - page no's, personal info
-\definecolor{color2}{HTML}{46535E} % Pacific Hex
-% \moderncvcolor{'#002676'}                           % color options: 'blue', 'orange', 'green', 'red', 'purple', 'grey' and 'black'
+% Color setup matches main.tex so both documents render with identical Berkeley
+% palette. moderncv reads \color1 (headings) and \color2 (accents) directly;
+% the older \moderncvcolor{...} command only accepts named colors and is not
+% used here.
+\definecolor{color0}{rgb}{0,0,0}                 % primary text
+\definecolor{color1}{HTML}{002676}               % Berkeley Blue (headings)
+\definecolor{color2}{HTML}{46535E}               % Berkeley Pacific (accents)
 
 \usepackage[scale=0.9]{geometry}
-\usepackage{fontawesome5}                      % for modern icons
+\usepackage{fontawesome5}
 \setlength{\footskip}{18pt}
 
 % personal data
@@ -25,64 +23,58 @@
 \address{San Francisco, CA}{}
 \phone[mobile]{(909) 993-3988}
 \email{ball@berkeley.edu}
-\homepage{mball.co}
+\homepage{https://mball.co}
 \social[github]{cycomachead}
-% \social[twitter]{_mball_}
 
 \begin{document}
 \makecvtitle
 
-\section{Education}
-\cventry{2015--2016}{M.S. Computer Science}{UC Berkeley, College of Engineering}{}{}{}
-% \cventry{2015--2016}{M.S. Computer Science}{University of California, Berkeley}{}{Advisor: Dr. Daniel Garcia}{\textit{Thesis: Lambda: An Autograder for Snap!}}
-\cventry{2011--2015}{B.A. Computer Science}{UC Berkeley, College of Letters \& Sciences}{}{}{}
-
 \section{Professional Experience}
-\cventry{2019--Present}{Lecturer}{UC Berkeley EECS Department}{Berkeley, CA}{}{
+\cventry{July 2025--Present}{Continuing Lecturer}{UC Berkeley EECS \& Data Science}{Berkeley, CA}{}{}
+
+\cventry{July 2019--June 2025}{Lecturer}{UC Berkeley EECS \& Data Science}{Berkeley, CA}{}{
 \begin{itemize}
-\item Full-time lecturer involved in EECS undergraduate curricular development and pedagogy
-\item Led courses including Data Science (C88C), Software Engineering (CS169A/L), Computer Science Fundamentals (CS88)
-\item Coordinated EECS Summer Instruction program (2022-2024)
-\item Member of Undergraduate Study Committee (2019-2024) and Student Grievances Committee (2020-2023)
+\item Teach Data Science (DATA C88C, 500+ students/term), Software Engineering (CS169A/L), and CS Pedagogy (CS302); recruit, train, and manage 10--30 teaching assistants and tutors per semester
+\item Co-Director, EECS Summer Instruction (2022--2026): oversee $\sim$10 courses and a \$100--250K operating budget per session, including hiring, payroll, and curriculum approval
+\item Principal/co-investigator on \$150K+ in instructional-technology grants funding accessibility, autograding, and curriculum-modernization projects
+\item Member, Undergraduate Study Committee (2019--2024); Student Grievances Committee (2020--2023)
 \end{itemize}}
 
-\cventry{2019--2021}{Part-Time Software Engineer}{TurnItIn}{Oakland, CA}{}{
+\cventry{2016--2021}{Software Engineer}{Gradescope (acquired by Turnitin, 2018)}{Berkeley, CA}{}{
 \begin{itemize}
-\item Early engineer from startup through acquisition by Turnitin
-\item Led web accessibility initiatives and presented at educational conferences
-\item Contributed to the design and development of autograding infrastructure
-\end{itemize}}
-
-\cventry{2016--2019}{Software Engineer}{Gradescope}{Berkeley, CA}{}{
-\begin{itemize}
-\item Early engineer from startup through acquisition by Turnitin
-\item Led web accessibility initiatives and presented at educational conferences
-\item Contributed to the design and development of autograding infrastructure
+\item Early engineer at a sub-15-person edtech startup through acquisition by Turnitin; transitioned to part-time in 2019 to focus on lecturer role
+\item Architected web-accessibility infrastructure to meet WCAG 2.0/2.1; built automated front-end accessibility testing and trained Turnitin's wider engineering organization
+\item Designed AWS-hosted data pipelines for product analytics, onboarding, and growth experimentation
+\item Contributed to autograding infrastructure design and partnered with the design team on new platform features
 \end{itemize}}
 
 \section{Software Projects}
-\cventry{}{Snap!}{}{}{}{
-A blocks-based visual programming language designed to teach computer science while exposing advanced concepts like lambdas and recursion. Contributed to core IDE and designed/built cloud infrastructure supporting 5M+ projects and 500K+ users. \texttt{https://snap.berkeley.edu}
+\cventry{}{Snap\textit{!} \normalfont\small\textemdash\ \texttt{snap.berkeley.edu}}{}{}{}{
+Co-architect of the open-source cloud platform powering this blocks-based visual programming language used by 500K+ educators and students worldwide; system serves 5M+ stored projects. Contribute to the core JavaScript IDE and own project-storage, sharing, and authentication services.
 }
 
-\cventry{}{Beauty and Joy of Computing (BJC)}{}{}{}{
-AP Computer Science Principles curriculum emphasizing programming and social implications of computing. Provided infrastructure maintenance, technical consulting, and curriculum development. \texttt{https://bjc.berkeley.edu}
+\cventry{}{Flextensions \normalfont\small\textemdash\ \texttt{github.com/berkeley-cdss/flextensions}}{}{}{}{
+Technical lead and architect of a Rails web application that automates assignment-extension requests, approvals, and Canvas LMS integration. Scaled from pilot to 10,000+ student enrollments across two semesters; designed deployment infrastructure and mentored 12+ undergraduate engineers shipping production code.
 }
 
-\cventry{}{Alonzo, A Staff Chatbot}{}{}{}{
-Chatbot automating grading processes for course staff, enabling efficient oral lab check-offs. Originally a side project that evolved with contributions from multiple generations of TAs. \texttt{https://github.com/cs10/Alonzo}
+\cventry{}{Beauty and Joy of Computing (BJC) \normalfont\small\textemdash\ \texttt{bjc.berkeley.edu}}{}{}{}{
+AP Computer Science Principles curriculum reaching tens of thousands of students annually. Maintain technical infrastructure, drive curriculum development, and provide engineering consulting across the open-source toolchain.
 }
 
 \section{Awards \& Grants}
-\cventry{2023--2025}{UC Berkeley Instructional Technology Grant}{}{}{}{Awarded \$100,000 to modernize educational tools for CS and Data Science courses}
-\cventry{2021--2022}{UC Berkeley Presidential Chair Fellows}{}{}{}{Awarded \$22,500 grant to add Parsons Problems to CS courses}
+\cventry{2023--2025}{UC Berkeley Instructional Technology Grants}{}{}{}{\$100,000 across two cycles to modernize educational tools for CS and Data Science courses}
+\cventry{2021--2022}{UC Berkeley Presidential Chair Fellows}{}{}{}{\$22,500 to introduce Parsons Problems into CS61A and CS88}
 \cventry{2019--2020}{UC Berkeley Lecturer Teaching Fellows}{}{}{}{Year-long project on Parsons Puzzles in intro CS courses}
-\cventry{2015}{Eugene L. Lawler Prize}{UC Berkeley EECS}{}{}{Honored for academic effort and surmounting difficulties}
 \cventry{2015}{EECS Distinguished Graduate Student Instructor Award}{UC Berkeley}{}{}{Selected from top 9\% of UC Berkeley EECS GSIs}
+\cventry{2015}{Eugene L. Lawler Prize}{UC Berkeley EECS}{}{}{For academic effort and surmounting unusual difficulties pursuing a CS degree}
 
 \section{Technical Skills}
-\cvitem{Languages}{Snap!, JavaScript, Ruby, Python, SQL, bash, CSS, HTML}
-\cvitem{Tools}{Git, React, AWS, Heroku, Terraform, PostgreSQL, accessibility testing}
-\cvitem{Media}{Semi-Professional Photography, Online events, Adobe Creative Suite, Final Cut Pro X}
+\cvitem{Languages}{JavaScript, Ruby, Python, SQL, Bash, HTML, CSS, Snap\textit{!}}
+\cvitem{Tools}{Rails, React, AWS, Heroku, Terraform, PostgreSQL, Git, accessibility testing}
+\cvitem{Practice}{System architecture, technical mentorship, web accessibility (WCAG 2.x), DevOps}
+
+\section{Education}
+\cventry{2015--2016}{M.S. Computer Science}{UC Berkeley, College of Engineering}{}{}{}
+\cventry{2011--2015}{B.A. Computer Science}{UC Berkeley, College of Letters \& Sciences}{}{}{}
 
 \end{document}


### PR DESCRIPTION
## Optimize one-page resume for senior SWE roles

Restructures and rewrites `one-page-resume.tex` to better target senior software engineering positions, fixes a LaTeX coloring bug, and adds CI automation to build and publish PDFs on every push to `main`.

## Changes

**Resume content**
- Moved **Education** to the bottom of the document
- Split Lecturer role into two entries: **Continuing Lecturer (July 2025–Present)** with no description, and **Lecturer (July 2019–June 2025)** with rewritten bullets emphasizing management of 10–30 TAs/tutors, $150K+ in grants, and a $100–250K per-session operating budget
- Added **Flextensions** project entry (Rails architect, 10K+ enrollments, mentored 12+ undergrad engineers)
- Rewrote **Snap!** description to highlight cloud platform architecture, scale (500K+ users, 5M+ projects), and ownership
- Consolidated duplicate Gradescope/Turnitin bullets (copy-paste bug) into a single entry with distinct, senior-SWE-relevant content (accessibility infra, AWS pipelines, autograding)
- Tightened Awards and Technical Skills sections; added a "Practice" skills line covering architecture, mentorship, accessibility, and DevOps

**LaTeX fixes**
- Replaced approximated `rgb{0.0,0.15,0.46}` with `HTML{002676}` (true Berkeley Blue) to match `main.tex`
- Removed broken `\moderncvcolor{'#002676'}` comment — `\moderncvcolor` only accepts named colors

**CI / repo hygiene**
- Added `.github/workflows/build-cv.yml`: builds both `main.tex` and `one-page-resume.tex` via `lualatex` on every push/PR, uploads PDFs as workflow artifacts (90-day retention), and publishes latest builds to a `pdfs` branch on merges to `main`
- Added `.gitignore` covering LaTeX build artifacts and editor noise

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/hkpwdgd7ztFH/implementations/mRgf8WRqMpdF) | [Guided Review](https://www.superconductor.com/tickets/hkpwdgd7ztFH/implementations/mRgf8WRqMpdF?tab=guided_review)

<!-- created-by-superconductor -->