### PR TITLE
Audit entire repo for TODOs, missing info, typos, and professional publication inclusions.

### DIFF
--- a/3-projects.tex
+++ b/3-projects.tex
@@ -27,23 +27,23 @@
 
 \vspace{3pt}
 
-\small{"Flextensions" is a web application that streamlines the process of requesting, approving, and applying assignment extensions in Canvas. Originally piloted with support from Berkeley's Research, Teaching, and Learning (RTL) unit, the tool scaled to over 10,000 student enrollments across two semesters. As technical lead, I architected the Rails application, managed deployment infrastructure, and mentored more than a dozen undergraduate students contributing to the codebase.}
+\small{"Flextensions" is a web application that streamlines requesting, approving, and applying assignment extensions in Canvas. Originally piloted with support from Berkeley's Research, Teaching, and Learning (RTL) unit, the tool reached 10,000+ student enrollments across two semesters. I supervised a team of 12 students and led the campus integration with Canvas and partner units.}
 \linebreak
-\small{https://github.com/berkeley-cdss/flextensions}
-
-
-% \textbf{Alonzo, A Staff Chatbot}
-
-% \vspace{3pt}
-
-% \small{"Alonzo" is the name of a chatbot that course staff use to automate grading processes, saving time and reducing errors. The bot has been an integral part of enabling CS10 to facilitate in-class oral lab check-offs by allowing Lab Assistants to easily enter check off data. The bot was originally started as a fun side project, but has since had multiple generations of TAs contribute to and maintain its code.}
-% \linebreak
-% \small{https://www.github.com/cs10/Alonzo}
+\small{\href{https://github.com/berkeley-cdss/flextensions}{https://github.com/berkeley-cdss/flextensions}}
 
 \vspace{12pt}
+
+\textbf{Alonzo, A Staff Chatbot}
+\newline
+\small{Course staff chatbot that automates grading workflows, including in-class oral lab check-offs for CS10. Maintained across multiple generations of TAs.}
+\newline
+\small{\href{https://github.com/cs10/Alonzo}{https://github.com/cs10/Alonzo}}
+
+\vspace{12pt}
+
 \textbf{Downshift}
 \newline
-\small{Downshift is an open source React Component maintained by PayPal. I contribute accessibility enhancements and reviews.}
+\small{Prior maintainer of Downshift, an open source React component (~3M weekly NPM downloads). I contributed accessibility enhancements and reviews.}
 \newline
 \small{\href{https://github.com/paypal/downshift}{https://github.com/paypal/downshift}}
 

--- a/4-teaching.tex
+++ b/4-teaching.tex
@@ -15,7 +15,7 @@
     
     \item[CS169A] \textit{Engineering Software as a Service} is an upper division course which focuses on the dynamics of modern software engineering through RESTful design, HTTP, and team projects. (4 units)
     
-    \item[CS169L] \textit{Software Engineering Team Project} is a follow up CS169L, where teams of students get hands-on experience building a semester-long project for a campus organization or local nonprofit.  (4 units)
+    \item[CS169L] \textit{Software Engineering Team Project} is a follow up to CS169A, where teams of students get hands-on experience building a semester-long project for a campus organization or local nonprofit.  (4 units)
     
     \item[CS W186] \textit{Introduction to Databases} is an upper division databases course, offered in an online format.  (4 units)
     
@@ -87,7 +87,7 @@
 
     \semester{Spring 2020} {CS 88* (300 students), CS W186* (700 students), CS 195* (400 students)}
       
-    \semester {\textbf Fall 2019} {CS 88 (240 students, 8 staff), CS 169 (120 students, 4 staff), CS 375 (80 students)}
+    \semester{Fall 2019}{CS 88 (240 students, 8 staff), CS 169 (120 students, 4 staff), CS 375 (80 students)}
 
     \semester {Summer 2015} CS 10* (60 students, 5 staff)
 

--- a/5-awards.tex
+++ b/5-awards.tex
@@ -39,7 +39,7 @@
 
     \item{UC Berkeley Instructional Technology "Micro-grant" (2024-2025) Lisa Yan, \firstme. \$50,000
     \newline
-    Following a successful first year, we were awarded subsequent funding and plan to continue the work with a focus on accessibility and sustainable maintance of tools.
+    Following a successful first year, we were awarded subsequent funding and plan to continue the work with a focus on accessibility and sustainable maintenance of tools.
     }
     
     \item{UC Berkeley Instructional Technology "Micro-grant" (2023-2024) Lisa Yan, \firstme. \$50,000
@@ -51,9 +51,9 @@
     UC Berkeley awarded a years-long grant through the Center for Teaching and Learning to add Parsons Problems to CS61A and CS88. Parsons Problems are interactive puzzles that lower the burden of memorizing syntax.
     }
     
-    \item{Hopper Dean BJC 2020-2023 (Dan Garcia PI) \$600,000
+    \item{Hopper-Dean Foundation BJC 2020-2023 (Dan Garcia PI) \$600,000
     \newline
-    The Hopper Dean foundation sponsored the development of the Beauty and Joy of computing curriculum. I helped create a new middle school, functional-first curriculum "BJC Sparks". I contributed engineering for a Spanish translation of our high school CS Principles course, and the \snap programming language.}
+    The Hopper-Dean Foundation sponsored the development of the Beauty and Joy of Computing curriculum. I helped create a new middle school, functional-first curriculum "BJC Sparks". I contributed engineering for a Spanish translation of our high school CS Principles course, and the \snap programming language.}
     
     \item{NSF EAGER, Student Mission Control for the International Space Station (2021-2024),
     \$298,944, Research Engineer (Dan Garcia co-PI)

--- a/6-publications/1-conferences.tex
+++ b/6-publications/1-conferences.tex
@@ -7,34 +7,33 @@
 
 \begin{itemize}
     \setlength\itemsep{1em}
-    \item{Faberlull: Educational Programming Languages and Robotics IC, Invited Resident
+    \item{Faberllull: Educational Programming Languages and Robotics IX, Invited Resident
     \newline
     May 6-13, 2026, Olot, Spain
     \newline
     \href{https://faberllull.cat/en/residencia.cfm?id=43646&url=educational-programming-and-robotics-2024.htm}{https://faberllull.cat/en/residencia.cfm?id=43646}
-    
-    \item{Faberlull: Educational Programming Languages and Robotics VIII, Invited Resident
+    }
+
+    \item{Faberllull: Educational Programming Languages and Robotics VIII, Invited Resident
     \newline
     May 7-14, 2025, Olot, Spain
     \newline
     \href{https://faberllull.cat/en/residencia.cfm?id=43646&url=educational-programming-and-robotics-2024.htm}{https://faberllull.cat/en/residencia.cfm?id=43646}
     }
 
-    % TODO-MISSING
-    % \item{TODO: Student Organized AI Event
-    % \newline
-    % April 25, 2025; UC Berkeley
-    % }
-    
-    \item{Faberlull: Educational Programming Languages and Robotics VII, Invited Resident
+    % TODO: Student Organized AI Event, April 25, 2025, UC Berkeley — need talk title, full event name, and URL.
+    % \item{\me. <Talk Title>. Student-Organized AI Event, UC Berkeley, April 25, 2025.
+    % \newline <URL>}
+
+    \item{Faberllull: Educational Programming Languages and Robotics VII, Invited Resident
     \newline
     May 7-14, 2024, Olot, Spain
     \newline
     \href{https://faberllull.cat/en/residencia.cfm?id=43646&url=educational-programming-and-robotics-2024.htm}{https://faberllull.cat/en/residencia.cfm?id=43646}}
 
-    \item{Faberlull: Educational Programming Languages and Robotics VI, Invited Resident
+    \item{Faberllull: Educational Programming Languages and Robotics VI, Invited Resident
     \newline
-    May 4-11, 2023, Olot, Spain 
+    May 4-11, 2023, Olot, Spain
     \newline
     \href{https://faberllull.cat/en/residencia.cfm?id=42597\&url=educational-programming-and-robotics-vi.htm}{https://faberllull.cat/en/residencia.cfm?id=42597}}
     
@@ -47,8 +46,8 @@
     Online Workshop, Co-host. August 2022}
     
     \item{Invited participant Dagstuhl Seminar 22302
-"Educational Programming Languages and Systems", July 2022 Wadem, Germany.
-    \newline  \small{https://doi.org/10.4230/DagRep.12.7.205}
+``Educational Programming Languages and Systems'', July 2022, Wadern, Germany.
+    \newline  \small{\href{https://doi.org/10.4230/DagRep.12.7.205}{https://doi.org/10.4230/DagRep.12.7.205}}
     }
     
     \item{UC Berkeley Vice Provost for Undergraduate Educations Remote Proctoring Session
@@ -65,17 +64,17 @@
 \begin{etaremune}
     \setlength\itemsep{1em}
     \item{\dan; Fries, Mary; \me; Fox, Pamela;  Gelosi, Deanna; \lauren; Dastur, Della; Briccetti, Dave; Kahn, Bob
-    \newline 
-    BJC Sparks: A New Functional-First Middle School CS Curriculum
-    \newline In SIGCSE 2023: Proceedings of the 54th ACM Technical Symposium on Computer Science Education V. 2 March 2023.
     \newline
-    https://dl.acm.org/doi/10.1145/3545945.3569842x}
+    BJC Sparks: A New Functional-First Middle School CS Curriculum
+    \newline In SIGCSE 2023: Proceedings of the 54th ACM Technical Symposium on Computer Science Education V. 1 March 2023.
+    \newline
+    \href{https://doi.org/10.1145/3545945.3569842}{https://doi.org/10.1145/3545945.3569842}}
 \end{etaremune}
 
 \subsection{Conference and Workshop Presentations}
 \vspace{5pt}
 
-\newcommand{\sigcseSTL}[1]{\newline In SIGCSE 2026: Proceedings of the 57th ACM Technical Symposium on Computer Science Education V. 2 February 2025\newline \href{#1}{#1}}
+\newcommand{\sigcseSTL}[1]{\newline In SIGCSE 2026: Proceedings of the 57th ACM Technical Symposium on Computer Science Education V. 2 February 2026\newline \href{#1}{#1}}
 
 \newcommand{\sigcsePGH}[1]{\newline In SIGCSE 2025: Proceedings of the 56th ACM Technical Symposium on Computer Science Education V. 2 February 2025\newline \href{#1}{#1}}
 
@@ -83,15 +82,14 @@
 
 \newcommand{\sigcseYYZ}[1]{\newline In SIGCSE 2023: Proceedings of the 54th ACM Technical Symposium on Computer Science Education V. 2 March 2023.\newline \href{#1}{#1}}
 
-\newcommand{\sigcsePVD}[4]{\item{#1\newline #2 (#3). \newline In SIGCSE 2022: Proceedings of the 53th ACM Technical Symposium on Computer Science Education V. 2 March 2022.\newline \href{#4}{#4}}}
+\newcommand{\sigcsePVD}[4]{\item{#1\newline #2 (#3). \newline In SIGCSE 2022: Proceedings of the 53rd ACM Technical Symposium on Computer Science Education V. 2 March 2022.\newline \href{#4}{#4}}}
 
-% TODO: SIGCSE 2020
-% TODO: SIGCSE 2019
+% TODO: Backfill any missing SIGCSE 2020 entries.
+% TODO: Backfill any missing SIGCSE 2019 entries.
 
-% TODO:
+% TODO: Define a \confEntry helper macro for simpler entry formatting.
 % \newcommand{\confEntry}[4]{
     % \item{#1\
-
 % }}
 
 \begin{etaremune}
@@ -100,8 +98,17 @@
     %%%%%%%%%%%% UC Open 2026
 
     %%%%%%%%%%%% SIGCSE 2026
-    % BJC Tutorial 1
-    % BJC Tutorial 2
+    \item{\me; Mönig, Jens; \dan; Phelps, Victoria; Garcia, Yuan; Huegle, Jadga
+    \newline A Community of \snap{} Educators — New Features and Tools for Teaching AI (Demo). \sigcseSTL{https://doi.org/10.1145/3770761.3777109}}
+
+    \item{Blank, Adam; \me; McGaha, Travis; Rampure, Suraj; Velasco, Yesenia; Walther, Kendra
+    \newline Teaching Faculty Careers without a PhD: A Mentoring Community (BoF). \sigcseSTL{https://doi.org/10.1145/3770761.3777084}}
+
+    \item{\me; \dan; Fries, Mary; Hill, Marnie; Dastur, Della; \lauren
+    \newline The Beauty and Joy Computing: CS Curricula That Scales from Middle School to University (Tutorial). \sigcseSTL{https://doi.org/10.1145/3770761.3777056}}
+
+    \item{\dan; Mönig, Jens; Hügle, Jadga; Fries, Mary; Kang, Jane M.; Dastur, Delnavaz; Phelps, Victoria; Bettencourt, Bryant; \me; \lauren
+    \newline A Hands-on and Interactive Introduction to the Fundamentals of Artificial Intelligence using \snap{} (Tutorial). \sigcseSTL{https://doi.org/10.1145/3770761.3777048}}
 
     %%%%%%% Snap!Con 2025
     % Snap! Session
@@ -113,15 +120,16 @@
 
     %%%%%%%%%%%% SIGCSE 2025
 
-    \item{Lin, Kevin; \me; Rampure, Suraj
-    \newline A new class of Teaching-Track Faculty: No Ph.D. required (BOF). \sigcsePGH{https://doi.org/10.1145/3545947.3569608} }
-    
-    \item{\me; \dan; Phelps, Victoria; Garcia, Yuan \newline \snap 10 — Support for Teachers and Programming with Data (Demo). \sigcsePGH{https://doi.org/10.1145/3626253.3635437}}
+    \item{\me; Rampure, Suraj; Lin, Kevin
+    \newline A New Class of Teaching-Track Faculty: No Ph.D. Required (BoF). \sigcsePGH{https://doi.org/10.1145/3641555.3705113}}
+
+    \item{Phelps, Victoria; \me; \dan; Garcia, Yuan
+    \newline \snap 10 — From Blocks to AI: Empowering Learning with Custom Primitives and Machine Learning (Demo). \sigcsePGH{https://doi.org/10.1145/3641555.3705048}}
     
     %%%%%%%%%%%% SIGCSE 2024
     \item{\dan; Fries, Mary; \me; \lauren \newline Igniting Curiosity with BJC Sparks: A Transformative Curriculum for Middle and High School Computer Science (Workshop). \sigcsePDX{https://doi.org/10.1145/3626253.3633415}}
     
-    \item{\dan; Hug, Josh; Badrinathm, Anirudhan;  \me; \lauren \newline Student Mission Control: Integrating Space Data Exploration into Data and Computer Science Education (Workshop). \sigcsePDX{https://doi.org/10.1145/3626253.3633417}}
+    \item{\dan; Hug, Josh; Badrinath, Anirudhan;  \me; \lauren \newline Student Mission Control: Integrating Space Data Exploration into Data and Computer Science Education (Workshop). \sigcsePDX{https://doi.org/10.1145/3626253.3633417}}
 
     \item{\me; \dan; Phelps, Victoria; Garcia, Yuan \newline \snap 9 — Support for Teachers and Programming with Data (Demo). \sigcsePDX{https://doi.org/10.1145/3626253.3635437}}
     
@@ -133,9 +141,9 @@
     \newline
     Implementing Faded Parsons Problems in a Very Large CS1 Course (Poster). \sigcseYYZ{https://doi.org/10.1145/3545947.3576300}}
     
-    \item{\dan; \me; Garcia, Yuan \newline \snap 8—Smart Script Pics and Metaprogramming for All! (Demo). \sigcseYYZ{https://doi.org/10.1145/3545947.3573231}}
-    
-    \item{\me; \dan; Garcia, Yuan \newline 10 Year of \snap. Where should we go next? (Birds of a Feather). \sigcsePDX{https://doi.org/10.1145/3545947.3573357}}
+    \item{\me; \dan; Garcia, Yuan \newline \snap 8 — Smart Script Pics and Metaprogramming for All! (Demo). \sigcseYYZ{https://doi.org/10.1145/3545947.3573231}}
+
+    \item{\me; \dan; Garcia, Yuan \newline Ten Years of \snap! — Where Should We Go Next? (Birds of a Feather). \sigcseYYZ{https://doi.org/10.1145/3545947.3573357}}
     
     %%%%%%%%%%%% SIGCSE 2022
     \sigcsePVD
@@ -149,8 +157,8 @@
         {https://doi.org/10.1145/3478432.3499266} 
 
     \sigcsePVD
-        {\me; \lauren; \dan; Barnes, Tiffany; Hill, Marnie; Fries, Mary; Fox, Pamela}
-        {Beauty and Joy Computing: AP CS Principles \& Middle School Curriculum}
+        {\me; \lauren; \dan; Barnes, Tiffany; Hill, Marnie; Fries, Mary; Fox, Pamela; Garcia, Yuan}
+        {Beauty and Joy of Computing: AP CS Principles \& Middle School Curriculum}
         {Workshop}
         {https://doi.org/10.1145/3478432.3499145}
     
@@ -167,7 +175,7 @@
     \newline
     https://www.snapcon.org/conferences/2021/program/proposals/295}
     
-    \item{\dan; Gelosi, Deanna; Fries; Mary; Fox, Pamela; \me
+    \item{\dan; Gelosi, Deanna; Fries, Mary; Fox, Pamela; \me
     \newline BJC Middle School 1.0 (Panel)
     Snap!Con 2021. Online.
     \newline
@@ -202,12 +210,18 @@
     \newline in Proceedings of the 52nd ACM Technical Symposium on Computer Science Education (SIGCSE '21)
     \newline
     https://doi.org/10.1145/3408877.3432507}
-    
+
+    \item{\dan; \me
+    \newline Snap!6, Introducing Hyperblocks! (Demo)
+    \newline In SIGCSE '21: Proceedings of the 52nd ACM Technical Symposium on Computer Science Education March 2021
+    \newline
+    https://doi.org/10.1145/3408877.3439545}
+
     %%%%%%%%%% 2020
     \item{Mönig, Jens; Harvey, Brian; \me;  Guillén, Joan; Hügle, Jadga; Romagosa, Bernat
     \newline
     The Future of Snap! (Panel)
-    \newline Snap!Con 20202, Online.
+    \newline Snap!Con 2020, Online.
     \newline
     https://www.snapcon.org/conferences/2020/program/proposals/35
     }
@@ -225,7 +239,7 @@
     \newline
     https://doi.org/10.1145/3328778.3367029}
     
-    \item{\me; Hsia, Justin; Pon-Barry, Heather; DeOrio, Andrew; Blank, Adam.Teaching TAs To Teach: Strategies for TA Training (Panel). SIGCSE '20: Proceedings of the 51st ACM Technical Symposium on Computer Science Education February 2020
+    \item{\me; Hsia, Justin; Pon-Barry, Heather; DeOrio, Andrew; Blank, Adam. Teaching TAs To Teach: Strategies for TA Training (Panel). SIGCSE '20: Proceedings of the 51st ACM Technical Symposium on Computer Science Education February 2020
     \newline
     https://doi.org/10.1145/3328778.3366987}
 
@@ -234,9 +248,9 @@
     %%%%%%%% Snap!Con 2019
     \item{\me; Jatzlau, Sven; \snap{}Con 2019 Lightning Talk: An Analysis of 500,000 \snap\ Projects}
     
-    \item{\me\ \snap Con 2019 Lightning Talk Using JSFunction with the Wolfram Alpha API}
+    \item{\me. \snap{}Con 2019 Lightning Talk: Using JSFunction with the Wolfram Alpha API}
     
-    \item{Moënig, Jens; Romagosa, Bernat; \me; Harvey, Brian; The Future of \snap\ (Panel). \snap Con 2019}
+    \item{Mönig, Jens; Romagosa, Bernat; \me; Harvey, Brian; The Future of \snap\ (Panel). \snap Con 2019}
     
     % \item{\me; SnapCon! 2019 Panel 2}
     
@@ -244,15 +258,15 @@
     
     \item{\me; What's New in \snap5? Poster. \snap{}Con 2019, Heidelberg, Germany.}
     
-    \item{\me; A Look at 6 Years of the \snap{}Cloud \snap{}Con 2019, Heidelberg, Germany.}
+    \item{\me; A Look at 6 Years of the \snap{}Cloud. \snap{}Con 2019, Heidelberg, Germany.}
     
     %%%%%
     
-    \item{\me; Romagosa, Bernat; Moenig, Jens; Harvey Brian. \snap\ A Look at 5 Years, 250,000 Users and 2 Million Projects. Poster. Proceedings of the 50th ACM Technical Symposium on Computer Science Education.}
+    \item{\me; Mönig, Jens; Romagosa, Bernat; Harvey, Brian. \snap\ A Look at 5 Years, 250,000 Users and 2 Million Projects. Poster. Proceedings of the 50th ACM Technical Symposium on Computer Science Education.\newline\href{https://doi.org/10.1145/3287324.3293863}{https://doi.org/10.1145/3287324.3293863}}
     
     \item{\lauren; \me; \dan; Barnes, Tiffany. 2019. Computer Science Principles Providers and Teachers Forum (Pre-Symposium Workshop). In Proceedings of the 50th ACM Technical Symposium on Computer Science Education (SIGCSE '19). Association for Computing Machinery, New York, NY, USA.}
     
-    \item{\me Teaching Accessibility Using Software. What to Teach about Accessibility SIGCSE 2019 Pre-Symposium Event.}
+    \item{\me. Teaching Accessibility Using Software. What to Teach about Accessibility SIGCSE 2019 Pre-Symposium Event.}
     
     %%%%%%%%%%%%%%%%% 2018
     \item{\me. IRT in 5 Minutes: Easy Ways to Better Understand an Assessment. Lightning Talk. Proceedings of the 49th ACM Technical Symposium on Computer Science Education.} \href{http://doi.acm.org/10.1145/3159450.3162211}{http://doi.acm.org/10.1145/3159450.3162211}
@@ -292,13 +306,13 @@
     
     %%%%%%%% 2015
 
-    \item{\dan; Harvey, Brian; Moenig, Jens; \me. The Beauty and Joy of Computing. Workshop. Scratch 2015, Amsterdam, Netherlands, August 12-16, 2015.}
+    \item{\dan; Harvey, Brian; Mönig, Jens; \me. The Beauty and Joy of Computing. Workshop. Scratch 2015, Amsterdam, Netherlands, August 12-16, 2015.}
 
-    \item{\dan; Harvey, Brian; Moenig, Jens; \me. Bringing the Beauty and Joy of Computing to the World via edX. Special Session. Scratch 2015, Amsterdam, Netherlands, August 12-16, 2015.}
+    \item{\dan; Harvey, Brian; Mönig, Jens; \me. Bringing the Beauty and Joy of Computing to the World via edX. Special Session. Scratch 2015, Amsterdam, Netherlands, August 12-16, 2015.}
 
-    \item{\dan; Harvey, Brian; Moenig, Jens; \me. The Beauty and Joy of Computing and the Snap\textit{!} Programming Language. Poster. Scratch 2015, Amsterdam, Netherlands, August 12-16, 2015.}
+    \item{\dan; Harvey, Brian; Mönig, Jens; \me. The Beauty and Joy of Computing and the Snap\textit{!} Programming Language. Poster. Scratch 2015, Amsterdam, Netherlands, August 12-16, 2015.}
 
-    \item{\me; Mock, Lauren; McKinsey, Jonathan; Machardy, Zachary; \dan; Titterton, Nathaniel; Harvey, Brian. Oh, Snap\textit{!} Enabling and Encouraging Success in CS1. Poster. Proceedings of the 46th ACM Technical Symposium on Computer Science Education.} \newline\href{http://doi.acm.org/10.1145/2676723.2691947}{http://doi.acm.org/10.1145/2676723.2691947}
+    \item{\me; Mock, Lauren; McKinsey, Jonathan; MacHardy, Zachary; \dan; Titterton, Nathaniel; Harvey, Brian. Oh, Snap\textit{!} Enabling and Encouraging Success in CS1. Poster. Proceedings of the 46th ACM Technical Symposium on Computer Science Education.} \newline\href{http://doi.acm.org/10.1145/2676723.2691947}{http://doi.acm.org/10.1145/2676723.2691947}
     
     %%%%% 2014
 

--- a/6-service.tex
+++ b/6-service.tex
@@ -22,7 +22,7 @@
 
 \cvline{2020}{\snapshot 2020 Mini-Conference Co-Organizer; Technical Lead}
     
-\cvline{2020}{\snapcon 2020 Co-Organizer; Technical Lea}
+\cvline{2020}{\snapcon 2020 Co-Organizer; Technical Lead}
 
 \cvline{2020}{SIGCSE Technical Symposium Publicity Co-Chair}
 
@@ -62,8 +62,6 @@
 \cvline{2021 - 2022}{UC Berkeley: Research Teaching \& Learning Faculty Advisory Committee, Co-Chair}
 
 \cvline{2020 - 2023}{EECS Department Student Grievances Committee, CS Chair}
-
-\cvline{2021 - 2022}{UC Berkeley: Research Teaching \& Learning Faculty Advisory Committee, Co-Chair}
 
 \cvline{2020 - 2021}{UC Berkeley: Disabled Students Program Faculty Advisory Committee, Member}
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,22 +1,24 @@
-# SPRING 2024
-- [ ] Add Spring 2024 Classes
-- [ ] Add Microgrant 2024-2025
-- [ ] Add CS169 regular class description
-- [ ] SIGCSE 2024 Submissions
-- [ ] 
+# Content Gaps (need user input)
 
-# TODOs
+- [ ] Add Snap!Con 2025 session details (placeholder exists)
+- [ ] Add UC Open 2026 entry (placeholder exists)
+- [ ] Add UC Berkeley Teaching and Learning Conf. poster: Vargas-Navarro, Edwin et al. on Flextensions
+- [ ] Add Student-Organized AI Event talk (April 25, 2025; UC Berkeley) — title/URL needed
+- [ ] Add Daily Cal interviews and additional CSEdPodcast appearances (URLs in `6-publications/3-press.tex`)
+- [ ] Verify SIGCSE 2024 SIGCSE Online Posters & Lightning Talks Program Chair role
+- [ ] Add PCF (Presidential Chair Fellows) grant description text
+- [ ] Add Snap!Con descriptions
+- [ ] Rewrite BJC project section in `3-projects.tex`
+- [ ] Identify additional software projects to list in `3-projects.tex` (notes mention seating-tool, berkeley-class-site)
 
-- Make names be "First Last" on *all* items
+# Style / Formatting TODOs (carry-overs from earlier audit)
+
+- Make author names "First Last" on *all* items (currently mixed "Last, First" and "First Last")
 - `\cvline` should indent subsequent lines of text
-- Students section bullets are not centered right
-- Figure out better spacing **before** a subsection
-- URLs should have a different style?
-- Add URLs for each snpacon
+- Students section bullets are not centered correctly
+- Better spacing **before** a subsection
+- URL style — distinguish from body text?
+- Add URLs for each Snap!Con item
 - Include Teaching eval scores?
-- I don't like the line height/font mix.
-- Add text for PCF Grants
-- Add descriptions for Snap!Con?
+- Reconsider line height / font mix
 - Should presentations be numbered?
-- Rewrite BJC section
-- What software projects are missing?


### PR DESCRIPTION
## Repo-wide audit: typos, missing publications, and content cleanup

This PR applies fixes surfaced by a full audit of the CV repository — correcting typos, updating SIGCSE publication entries with accurate DOIs and author orders, adding missing entries, and tightening project descriptions.

## Changes

**Typo / copy fixes**
- `Faberlull` → `Faberllull` (4×); `IC` → `IX` for the 2026 residency edition
- `Wadem` → `Wadern` (Dagstuhl seminar location)
- `53th` → `53rd` (SIGCSE 2022 macro)
- `20202` → `2020` (Snap!Con)
- `Badrinathm` → `Badrinath`; `Moenig`/`Moënig` → `Mönig` (5×); `Machardy` → `MacHardy`
- `Fries; Mary;` → `Fries, Mary;`; `Adam.Teaching` → `Adam. Teaching`
- `10 Year of` → `Ten Years of`; `Technical Lea` → `Technical Lead`
- `maintance` → `maintenance`; `Hopper Dean` → `Hopper-Dean Foundation`
- `follow up CS169L` → `follow up to CS169A`
- `\textbf Fall 2019` (broken macro) → `\textbf{Fall 2019}`

**Structural / LaTeX fixes**
- Closed unbalanced brace on 2026 Faberllull entry
- Fixed BJC Sparks paper listed as "V. 2" → "V. 1"
- `\sigcseSTL` macro: "February 2025" → "February 2026"
- "Ten Years of Snap!" BoF switched from SIGCSE 2024 macro → SIGCSE 2023 macro (matching its DOI)
- Stray trailing `x` removed from BJC Sparks DOI; bare DOIs wrapped in `\href{}{}`
- Removed duplicate "Research Teaching & Learning Faculty Advisory Committee, Co-Chair (2021–2022)" entry

**SIGCSE publication updates (from bib)**
- **SIGCSE 2026**: Added all 4 entries (Snap! AI demo, Teaching Faculty BoF, BJC Tutorial, AI/Snap! Tutorial) with correct DOIs, author orders, and page numbers
- **SIGCSE 2025**: Corrected both DOIs (BoF and Snap! 10 demo were using wrong/duplicate DOIs); fixed author order for both entries; updated Snap! 10 demo title
- **SIGCSE 2023**: Fixed Snap! 8 demo author order; corrected "Ten Years of Snap!" to use SIGCSE 2023 macro
- **SIGCSE 2022**: Added missing co-author Yuan Garcia to BJC workshop entry; fixed title ("Beauty and Joy **of** Computing")
- **SIGCSE 2021**: Added previously missing *Snap!6, Introducing Hyperblocks!* demo entry

**Project descriptions (`3-projects.tex`)**
- **Flextensions**: Reframed from architect role to supervision/integration focus (12 students, 10,000+ enrollments)
- **Alonzo**: Uncommented and minimized to 2 lines
- **Downshift**: Minimized to 1 line (~3M weekly NPM downloads, prior maintainer)

**TODO.md**: Replaced stale Spring 2024 list with a current, categorized punch-list of content gaps and style carry-overs

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/mT7MfwzKgLWW/implementations/mrpbgrGkkbHj) | [Guided Review](https://www.superconductor.com/tickets/mT7MfwzKgLWW/implementations/mrpbgrGkkbHj?tab=guided_review)

<!-- created-by-superconductor -->