### PR TITLE
Create automatically updated professional webpage deployed via GitHub Pages with CI, including link to mball.co, auto-compiled PDF, and removal of ...

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,58 @@
+name: Build & deploy CV site
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compile public CV (lualatex)
+        uses: xu-cheng/latex-action@v3
+        with:
+          root_file: public.tex
+          latexmk_use_lualatex: true
+
+      - name: Assemble Pages artifact
+        run: |
+          set -euo pipefail
+          mkdir -p _site
+          cp -R site/. _site/
+          cp public.pdf _site/cv.pdf
+          build_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          build_display="$(date -u +'%B %-d, %Y')"
+          sed -i "s|__BUILD_DATE__|${build_iso}|g" _site/index.html
+          sed -i "s|__BUILD_DATE_DISPLAY__|${build_display}|g" _site/index.html
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# LaTeX build artifacts
+*.aux
+*.bbl
+*.bcf
+*.blg
+*.fdb_latexmk
+*.fls
+*.idx
+*.ilg
+*.ind
+*.log
+*.lof
+*.lot
+*.nav
+*.out
+*.run.xml
+*.snm
+*.synctex.gz
+*.toc
+*.vrb
+*.xdv
+
+# Generated PDFs
+main.pdf
+public.pdf
+cv.pdf
+one-page-resume.pdf
+
+# Pages build output
+_site/
+
+# OS
+.DS_Store

--- a/main.tex
+++ b/main.tex
@@ -97,7 +97,9 @@
     \input{6-publications/3-press}
     \input{3-projects}
     \input{7-personal}
-    \input{references}
+    \ifdefined\publicversion\else
+        \input{references}
+    \fi
 
     % \input{bibtex_post}
     

--- a/public.tex
+++ b/public.tex
@@ -1,0 +1,4 @@
+% Wrapper that builds main.tex without the personal references section.
+% Used by the GitHub Pages deploy workflow.
+\def\publicversion{1}
+\input{main}

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Michael Ball — Curriculum Vitae</title>
+  <meta name="description" content="Curriculum vitae of Michael Ball, Continuing Lecturer at UC Berkeley EECS &amp; Data Science.">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main>
+    <header>
+      <p class="eyebrow">Curriculum Vitae</p>
+      <h1>Michael Ball</h1>
+      <p class="subtitle">Continuing Lecturer &middot; UC Berkeley EECS &amp; Data Science</p>
+    </header>
+
+    <section class="bio">
+      <p>I'm a software engineer and educator at UC Berkeley, where I teach undergraduate computing courses and contribute to open-source educational software, including <a href="https://snap.berkeley.edu">Snap!</a> and <a href="https://bjc.berkeley.edu">The Beauty and Joy of Computing</a>. My work focuses on CS education, web accessibility, and tooling that helps teachers and students.</p>
+    </section>
+
+    <nav class="links" aria-label="Primary">
+      <a class="primary" href="cv.pdf">Download CV (PDF)</a>
+      <a href="https://mball.co">mball.co</a>
+      <a href="https://github.com/cycomachead">GitHub</a>
+      <a href="mailto:ball@berkeley.edu">ball@berkeley.edu</a>
+    </nav>
+
+    <footer>
+      <p>This page and the linked CV are built automatically from <a href="https://github.com/cycomachead/cv">cycomachead/cv</a>. Last built <time datetime="__BUILD_DATE__">__BUILD_DATE_DISPLAY__</time>.</p>
+    </footer>
+  </main>
+</body>
+</html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,147 @@
+:root {
+  --berkeley-blue: #002676;
+  --berkeley-blue-dark: #001a52;
+  --pacific: #46535e;
+  --bg: #fbfaf7;
+  --surface: #ffffff;
+  --text: #1a1a1a;
+  --muted: #5b6470;
+  --rule: #e3e2dd;
+  --max-width: 720px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Source Sans Pro",
+    "Helvetica Neue", Arial, sans-serif;
+  font-size: 17px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+main {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: clamp(2.5rem, 6vw, 5rem) clamp(1.25rem, 4vw, 2rem);
+}
+
+a {
+  color: var(--berkeley-blue);
+  text-decoration: none;
+  text-underline-offset: 3px;
+}
+
+a:hover,
+a:focus-visible {
+  text-decoration: underline;
+}
+
+header {
+  margin-bottom: 2.5rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--pacific);
+}
+
+h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(2.25rem, 6vw, 3rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--berkeley-blue);
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--pacific);
+}
+
+.bio {
+  margin: 0 0 2.5rem;
+}
+
+.bio p {
+  margin: 0;
+  font-size: 1.075rem;
+  color: #2c2f33;
+}
+
+.links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem 1.5rem;
+  padding: 1.25rem 0;
+  margin: 0 0 3rem;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+
+.links a {
+  font-weight: 500;
+}
+
+.links a.primary {
+  background: var(--berkeley-blue);
+  color: #fff;
+  padding: 0.55rem 1rem;
+  border-radius: 6px;
+  font-weight: 600;
+  transition: background 120ms ease;
+}
+
+.links a.primary:hover,
+.links a.primary:focus-visible {
+  background: var(--berkeley-blue-dark);
+  text-decoration: none;
+}
+
+footer {
+  font-size: 0.92rem;
+  color: var(--muted);
+}
+
+footer a {
+  color: var(--muted);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #14161a;
+    --surface: #1c1f24;
+    --text: #e9ecf1;
+    --muted: #9aa3ad;
+    --rule: #2a2e35;
+    --berkeley-blue: #6f8dd1;
+    --berkeley-blue-dark: #8aa6e0;
+    --pacific: #aab3bd;
+  }
+
+  .bio p {
+    color: #d6d9de;
+  }
+
+  .links a.primary {
+    color: #0d1117;
+  }
+}


### PR DESCRIPTION
## Add automated CV website deployed via GitHub Pages

Sets up a CI/CD pipeline that compiles the CV as a PDF and publishes a professional landing page to GitHub Pages on every push to `main`.

## Changes

- **`.github/workflows/deploy.yml`** — GitHub Actions workflow that compiles `public.tex` with LuaLaTeX, assembles the static site (with build date stamping), and deploys to GitHub Pages
- **`public.tex`** — thin wrapper that defines `\publicversion` and inputs `main.tex`, used to produce a public-safe PDF
- **`main.tex`** — wraps `\input{references}` in an `\ifdefined\publicversion\else…\fi` guard so the personal references section is excluded from public builds but retained for local compilation
- **`site/index.html`** — minimal landing page with a "Download CV (PDF)" button, links to [mball.co](https://mball.co), GitHub, and email, plus an auto-stamped build date
- **`site/styles.css`** — Berkeley-blue palette, responsive layout, system font stack, dark mode support
- **`.gitignore`** — excludes LaTeX build artifacts, generated PDFs, and `_site/`

## Setup Required

After merging, enable GitHub Pages in **Settings → Pages → Build and deployment** and set the source to **GitHub Actions**. The first workflow run will publish the site.

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/kHncBpCqwPDM/implementations/tWPkLzjGGwGR) | [Guided Review](https://www.superconductor.com/tickets/kHncBpCqwPDM/implementations/tWPkLzjGGwGR?tab=guided_review)

<!-- created-by-superconductor -->