### PR TITLE
Implement CV page with embedded sidebar, custom colors, dark mode toggle, and download buttons

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,18 +47,28 @@ jobs:
       - name: Run tests
         run: bundle exec rake test
 
-      - name: Render cv.md
-        run: bundle exec rake site:md
+      - name: Render cv-embed.md + sidebar fragment + assets
+        run: bundle exec rake site:embed
 
       # ---------- 3. Stage the files for the external repo ----------
+      # The Jekyll site at cycomachead.github.io/cv/ consumes:
+      #   index.md            — markdown body, no in-page header (the site
+      #                         layout supplies its own page title)
+      #   cv-sidebar.html     — sidebar fragment with download buttons +
+      #                         section TOC + dark mode toggle
+      #   cv.css, cv-theme.js — the styles + script the sidebar/body need
+      #   cv.pdf, resume.pdf  — the download targets
       - name: Stage deploy bundle
         run: |
           set -euo pipefail
           mkdir -p _deploy
-          cp build/cv.md          _deploy/index.md
-          cp public.pdf           _deploy/cv.pdf
-          cp main.pdf             _deploy/cv-full.pdf
-          cp one-page-resume.pdf  _deploy/resume.pdf
+          cp build/cv-embed.md         _deploy/index.md
+          cp build/cv-sidebar.html     _deploy/cv-sidebar.html
+          cp build/cv.css              _deploy/cv.css
+          cp build/cv-theme.js         _deploy/cv-theme.js
+          cp public.pdf                _deploy/cv.pdf
+          cp main.pdf                  _deploy/cv-full.pdf
+          cp one-page-resume.pdf       _deploy/resume.pdf
           ls -la _deploy
 
       # ---------- 4. Push to cycomachead/cycomachead.github.io ----------

--- a/Makefile
+++ b/Makefile
@@ -21,17 +21,34 @@ TEX_FILES  := main.tex one-page-resume.tex
 PDFS       := $(TEX_FILES:.tex=.pdf)
 DEPLOY_DIR := $(BUILD_DIR)/deploy
 
-.PHONY: all md preview pdf tex cv-pdf pubs-tex deploy-out test dblp clean help
+.PHONY: all md md-embed embed preview sidebar pdf tex cv-pdf pubs-tex deploy-out test dblp clean help
 
-all: md preview pdf
+all: md preview embed pdf
 
 # ---------------- Markdown (canonical output) ----------------
 md:
 	@$(RUBY) bin/cv md
 
+# Header-stripped Markdown for the Jekyll embed (no name/title/contact block).
+md-embed:
+	@$(RUBY) bin/cv md:embed
+
+# Sidebar fragment (download buttons + TOC + theme toggle) for the Jekyll site.
+sidebar: md
+	@$(RUBY) bin/cv sidebar
+
+# Full embed bundle: cv-embed.md + cv-sidebar.html + cv.css + cv-theme.js.
+embed:
+	@$(RUBY) bin/cv embed
+
 # ---------------- HTML preview ----------------
+# Copies the built PDFs into $(BUILD_DIR)/ as cv.pdf / resume.pdf so the
+# sidebar download buttons resolve when the preview is served from build/.
 preview: md
 	@$(RUBY) bin/cv preview
+	@if [ -f public.pdf ]; then cp -f public.pdf $(BUILD_DIR)/cv.pdf; \
+	elif [ -f main.pdf ]; then cp -f main.pdf $(BUILD_DIR)/cv.pdf; fi
+	@if [ -f one-page-resume.pdf ]; then cp -f one-page-resume.pdf $(BUILD_DIR)/resume.pdf; fi
 	@echo "Serving $(BUILD_DIR)/cv.html at http://localhost:$(PORT)"
 	@cd $(BUILD_DIR) && $(RUBY) -run -e httpd . -p $(PORT)
 
@@ -55,15 +72,19 @@ pubs-tex:
 	@$(RUBY) bin/cv pubs:tex $(BUILD_DIR)/publications.tex
 
 # ---------------- Deploy bundle ----------------
-# Stage cv.md + the two PDFs in build/deploy/, ready to copy into the
-# cycomachead/cycomachead.github.io repo's cv/ folder. The CI workflow does
-# this directly to the external repo; this target is for local dry-runs.
-deploy-out: md pdf
+# Stage cv-embed.md + sidebar fragment + assets + PDFs in build/deploy/, ready
+# to copy into the cycomachead/cycomachead.github.io repo's cv/ folder. The
+# CI workflow does this directly to the external repo; this target is for
+# local dry-runs.
+deploy-out: md-embed sidebar pdf
 	@mkdir -p $(DEPLOY_DIR)
-	@cp $(BUILD_DIR)/cv.md  $(DEPLOY_DIR)/index.md
-	@cp main.pdf            $(DEPLOY_DIR)/cv.pdf
-	@cp one-page-resume.pdf $(DEPLOY_DIR)/resume.pdf
-	@echo "staged $(DEPLOY_DIR)/{index.md, cv.pdf, resume.pdf}"
+	@cp $(BUILD_DIR)/cv-embed.md                $(DEPLOY_DIR)/index.md
+	@cp $(BUILD_DIR)/cv-sidebar.html            $(DEPLOY_DIR)/cv-sidebar.html
+	@cp templates/markdown/preview.css          $(DEPLOY_DIR)/cv.css
+	@cp templates/markdown/cv-theme.js          $(DEPLOY_DIR)/cv-theme.js
+	@cp main.pdf                                $(DEPLOY_DIR)/cv.pdf
+	@cp one-page-resume.pdf                     $(DEPLOY_DIR)/resume.pdf
+	@echo "staged $(DEPLOY_DIR)/{index.md, cv-sidebar.html, cv.css, cv-theme.js, cv.pdf, resume.pdf}"
 
 # ---------------- DBLP refresh ----------------
 # Pull the latest BibTeX export for the DBLP author profile. Manually merge
@@ -85,14 +106,17 @@ clean:
 
 help:
 	@echo "Targets:"
-	@echo "  make            build cv.md, cv.html, and both PDFs"
+	@echo "  make            build cv.md, cv.html, embed bundle, and both PDFs"
 	@echo "  make md         build $(BUILD_DIR)/cv.md from YAML+bib"
+	@echo "  make md-embed   build $(BUILD_DIR)/cv-embed.md (no page header) for Jekyll"
 	@echo "  make preview    build cv.html and serve it on http://localhost:$(PORT)"
+	@echo "  make sidebar    build $(BUILD_DIR)/cv-sidebar.html (Jekyll include)"
+	@echo "  make embed      cv-embed.md + cv-sidebar.html + cv.css + cv-theme.js"
 	@echo "  make pdf        build $(PDFS) via latexmk (requires lualatex)"
 	@echo "  make tex        scaffold $(BUILD_DIR)/cv.tex from YAML+bib"
 	@echo "  make cv-pdf     scaffold + compile $(BUILD_DIR)/cv.pdf"
 	@echo "  make pubs-tex   regenerate publications.tex from YAML+bib"
-	@echo "  make deploy-out stage cv.md + PDFs for cycomachead.github.io/cv/"
+	@echo "  make deploy-out stage embed bundle + PDFs for cycomachead.github.io/cv/"
 	@echo "  make test       run the minitest suite"
 	@echo "  make dblp       refresh dblp.bib from DBLP"
 	@echo "  make clean      remove build/ and LaTeX intermediates"

--- a/Rakefile
+++ b/Rakefile
@@ -19,17 +19,42 @@ namespace :site do
     puts "wrote #{out}"
   end
 
+  desc 'Render the header-stripped Markdown for the Jekyll embed (build/cv-embed.md)'
+  task :md_embed do
+    out = CV::Markdown.build_embed
+    puts "wrote #{out}"
+  end
+
   desc 'Build a standalone HTML preview (build/cv.html)'
   task preview: :md do
     out = CV::Preview.build
     puts "wrote #{out}"
   end
 
-  desc 'Stage cv.md + PDFs for the cycomachead.github.io/cv/ deploy'
-  task deploy_out: :md do
+  desc 'Build the cv-sidebar.html fragment for the Jekyll site (build/cv-sidebar.html)'
+  task sidebar: :md do
+    out = CV::Sidebar.build
+    puts "wrote #{out}"
+  end
+
+  desc 'Build the embed bundle: cv-embed.md + cv-sidebar.html + cv.css + cv-theme.js'
+  task embed: %i[md_embed sidebar] do
+    %w[preview.css cv-theme.js].each do |asset|
+      src  = CV::TEMPLATE_DIR.join('markdown', asset)
+      dest = CV::BUILD_DIR.join(asset == 'preview.css' ? 'cv.css' : asset)
+      FileUtils.cp(src, dest)
+      puts "wrote #{dest}"
+    end
+  end
+
+  desc 'Stage cv-embed.md + sidebar + assets + PDFs for the cycomachead.github.io/cv/ deploy'
+  task deploy_out: %i[md_embed sidebar] do
     deploy = CV::BUILD_DIR.join('deploy')
     FileUtils.mkdir_p(deploy)
-    FileUtils.cp(CV::Markdown::DEFAULT_OUTPUT, deploy.join('index.md'))
+    FileUtils.cp(CV::Markdown::EMBED_DEFAULT_OUTPUT,    deploy.join('index.md'))
+    FileUtils.cp(CV::Sidebar::DEFAULT_OUTPUT,           deploy.join('cv-sidebar.html'))
+    FileUtils.cp(CV::TEMPLATE_DIR.join('markdown', 'preview.css'), deploy.join('cv.css'))
+    FileUtils.cp(CV::TEMPLATE_DIR.join('markdown', 'cv-theme.js'), deploy.join('cv-theme.js'))
     %w[main.pdf one-page-resume.pdf].each do |pdf|
       src = CV::ROOT.join(pdf)
       next unless src.exist?

--- a/bin/cv
+++ b/bin/cv
@@ -3,7 +3,10 @@
 
 # Tiny CLI for the dual-publishing system. Usage:
 #   bin/cv md            — render YAML+bib to build/cv.md
+#   bin/cv md:embed      — render header-stripped Markdown for the Jekyll embed
 #   bin/cv preview       — render md and convert to a standalone HTML preview
+#   bin/cv sidebar       — render the cv-sidebar.html include for the Jekyll site
+#   bin/cv embed         — render md:embed + sidebar + copy cv.css/cv-theme.js
 #   bin/cv pubs:tex [out] — render a publications LaTeX fragment
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
@@ -15,10 +18,27 @@ case cmd
 when 'md', 'markdown'
   out = CV::Markdown.build
   puts "wrote #{out}"
+when 'md:embed'
+  out = CV::Markdown.build_embed
+  puts "wrote #{out}"
 when 'preview'
   CV::Markdown.build
   out = CV::Preview.build
   puts "wrote #{out}"
+when 'sidebar'
+  CV::Markdown.build unless File.file?(CV::Markdown::DEFAULT_OUTPUT)
+  out = CV::Sidebar.build
+  puts "wrote #{out}"
+when 'embed'
+  require 'fileutils'
+  CV::Markdown.build_embed
+  CV::Sidebar.build
+  %w[preview.css cv-theme.js].each do |asset|
+    src  = CV::TEMPLATE_DIR.join('markdown', asset)
+    dest = CV::BUILD_DIR.join(asset == 'preview.css' ? 'cv.css' : asset)
+    FileUtils.cp(src, dest)
+    puts "wrote #{dest}"
+  end
 when 'tex'
   out = CV::Latex.build
   puts "wrote #{out}"
@@ -38,7 +58,10 @@ when 'help', '-h', '--help'
   puts <<~USAGE
     Usage: bin/cv <command>
       md                Build the canonical Markdown CV (build/cv.md)
+      md:embed          Build the header-stripped Markdown for the Jekyll embed
       preview           Build cv.md and a standalone HTML preview (build/cv.html)
+      sidebar           Build the cv-sidebar.html fragment for the Jekyll site
+      embed             md:embed + sidebar + copy cv.css and cv-theme.js
       tex               Render the full single-file LaTeX CV (build/cv.tex)
       pubs:tex [path]   Render only the publications LaTeX fragment
 

--- a/lib/cv.rb
+++ b/lib/cv.rb
@@ -15,5 +15,6 @@ module CV
   autoload :Renderer, 'cv/renderer'
   autoload :Markdown, 'cv/markdown'
   autoload :Latex,    'cv/latex'
+  autoload :Sidebar,  'cv/sidebar'
   autoload :Preview,  'cv/preview'
 end

--- a/lib/cv/markdown.rb
+++ b/lib/cv/markdown.rb
@@ -8,20 +8,30 @@ module CV
   # front matter, suitable for either local kramdown preview or dropping into
   # a Jekyll site.
   module Markdown
-    DEFAULT_OUTPUT = CV::BUILD_DIR.join('cv.md')
+    DEFAULT_OUTPUT       = CV::BUILD_DIR.join('cv.md')
+    EMBED_DEFAULT_OUTPUT = CV::BUILD_DIR.join('cv-embed.md')
 
     module_function
 
-    def build(output: DEFAULT_OUTPUT, jekyll: true, data: nil, bib: nil)
+    def build(output: DEFAULT_OUTPUT, jekyll: true, page_header: true, data: nil, bib: nil)
       data ||= CV::Data.load
       bib  ||= CV::Bib.load
       renderer = CV::Renderer.new(format: :markdown)
 
       body = renderer.render('cv', data: data, bib: bib,
-                                   locals: { jekyll_front_matter: jekyll })
+                                   locals: { jekyll_front_matter: jekyll,
+                                             page_header:        page_header })
       FileUtils.mkdir_p(File.dirname(output))
       File.write(output, body)
       output
+    end
+
+    # Variant for the Jekyll site: keeps front matter, drops the in-page
+    # name/title/contact/bio block. The deployed page already has its own
+    # site-level page header, and the CV-specific download buttons + TOC
+    # live in the sidebar include rather than the markdown.
+    def build_embed(output: EMBED_DEFAULT_OUTPUT, data: nil, bib: nil)
+      build(output: output, jekyll: true, page_header: false, data: data, bib: bib)
     end
   end
 end

--- a/lib/cv/preview.rb
+++ b/lib/cv/preview.rb
@@ -5,14 +5,17 @@ require 'fileutils'
 module CV
   # Local-preview pipeline: take the rendered cv.md and convert it to a
   # standalone HTML file using kramdown (the same renderer Jekyll uses), then
-  # wrap it in a minimal HTML shell with a sidebar table of contents and the
-  # preview CSS so you can open the file in a browser without running Jekyll.
+  # wrap it in a minimal HTML shell that mirrors what the deployed Jekyll
+  # site will look like — sidebar with download buttons + section TOC + dark
+  # mode toggle, content column with the rendered CV body.
   module Preview
     DEFAULT_OUTPUT = CV::BUILD_DIR.join('cv.html')
 
     module_function
 
-    def build(input: CV::Markdown::DEFAULT_OUTPUT, output: DEFAULT_OUTPUT)
+    def build(input: CV::Markdown::DEFAULT_OUTPUT, output: DEFAULT_OUTPUT,
+              cv_pdf_url: CV::Sidebar::DEFAULT_CV_PDF_URL,
+              resume_pdf_url: CV::Sidebar::DEFAULT_RESUME_PDF_URL)
       require 'kramdown'
       require 'kramdown-parser-gfm'
 
@@ -25,48 +28,25 @@ module CV
         smart_quotes: %w[apos rsquo apos rsquo]
       ).to_html
 
-      sidebar = build_sidebar(html_body)
+      sidebar = CV::Sidebar.render(html_body: html_body,
+                                   cv_pdf_url: cv_pdf_url,
+                                   resume_pdf_url: resume_pdf_url)
       shell   = File.read(CV::TEMPLATE_DIR.join('markdown', 'preview.html.erb'),
                           encoding: 'UTF-8')
       css     = File.read(CV::TEMPLATE_DIR.join('markdown', 'preview.css'),
+                          encoding: 'UTF-8')
+      script  = File.read(CV::TEMPLATE_DIR.join('markdown', 'cv-theme.js'),
                           encoding: 'UTF-8')
 
       html = shell.sub('{{TITLE}}',   'Michael Ball — CV')
                   .sub('{{CSS}}',     css)
                   .sub('{{SIDEBAR}}', sidebar)
                   .sub('{{BODY}}',    html_body)
+                  .sub('{{SCRIPT}}',  script)
 
       FileUtils.mkdir_p(File.dirname(output))
       File.write(output, html)
       output
-    end
-
-    # Extract the rendered <h2 id="…">Title</h2> (and h3) blocks and build a
-    # nested sidebar nav. We keep this naive because the input is the output
-    # of our own template — no need for a full HTML parser.
-    def build_sidebar(html_body)
-      nav = +'<nav class="toc" aria-label="Section navigation">' "\n  <ol>\n"
-      open_h2 = open_h3 = false
-      html_body.scan(%r{<h([23])\s+id="([^"]+)"[^>]*>(.*?)</h\1>}m).each do |level, id, label|
-        text = label.gsub(/<[^>]+>/, '').strip
-        if level == '2'
-          nav << "    </ol>\n" if open_h3
-          nav << "  </li>\n"   if open_h2
-          nav << %(  <li><a href="##{id}">#{text}</a>)
-          open_h2 = true
-          open_h3 = false
-        else
-          unless open_h3
-            nav << "\n    <ol>\n"
-            open_h3 = true
-          end
-          nav << %(      <li><a href="##{id}">#{text}</a></li>\n)
-        end
-      end
-      nav << "    </ol>\n" if open_h3
-      nav << "  </li>\n"   if open_h2
-      nav << "  </ol>\n</nav>\n"
-      nav
     end
   end
 end

--- a/lib/cv/sidebar.rb
+++ b/lib/cv/sidebar.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'erb'
+require 'fileutils'
+
+module CV
+  # Build the sidebar HTML fragment that wraps the rendered CV. Used by:
+  #   - CV::Preview (inlined into the standalone preview cv.html)
+  #   - CV::Sidebar.build (writes build/cv-sidebar.html for the Jekyll deploy
+  #     to include verbatim alongside the rendered Markdown body)
+  #
+  # The fragment contains: the download buttons (CV + 1-page resume), the
+  # section TOC built from the rendered <h2>/<h3> ids, and the dark/light
+  # theme toggle.
+  module Sidebar
+    DEFAULT_OUTPUT = CV::BUILD_DIR.join('cv-sidebar.html')
+    TEMPLATE       = CV::TEMPLATE_DIR.join('markdown', 'sidebar.html.erb')
+
+    DEFAULT_CV_PDF_URL     = 'cv.pdf'
+    DEFAULT_RESUME_PDF_URL = 'resume.pdf'
+
+    module_function
+
+    # Render the sidebar fragment as a string.
+    def render(html_body:, cv_pdf_url: DEFAULT_CV_PDF_URL,
+               resume_pdf_url: DEFAULT_RESUME_PDF_URL)
+      toc_html = build_toc(html_body)
+      template = ERB.new(File.read(TEMPLATE, encoding: 'UTF-8'), trim_mode: '-')
+      template.filename = TEMPLATE.to_s
+
+      ctx = SidebarContext.new(
+        cv_pdf_url:     cv_pdf_url,
+        resume_pdf_url: resume_pdf_url,
+        toc_html:       toc_html
+      )
+      template.result(ctx.get_binding)
+    end
+
+    # Write the sidebar fragment to disk for the Jekyll site to include.
+    # The fragment is self-contained HTML — drop it into a Jekyll
+    # `_includes/cv-sidebar.html` and it works as long as the page also
+    # loads cv.css and cv-theme.js.
+    def build(output: DEFAULT_OUTPUT, html_body: nil,
+              cv_pdf_url: DEFAULT_CV_PDF_URL,
+              resume_pdf_url: DEFAULT_RESUME_PDF_URL)
+      html_body ||= read_rendered_body
+      fragment = render(html_body: html_body,
+                        cv_pdf_url: cv_pdf_url,
+                        resume_pdf_url: resume_pdf_url)
+      FileUtils.mkdir_p(File.dirname(output))
+      File.write(output, fragment)
+      output
+    end
+
+    # Extract the rendered <h2 id="…">Title</h2> (and h3) blocks from the
+    # CV body and build a nested <ol>. We keep this naive because the input
+    # is the output of our own template — no need for a full HTML parser.
+    def build_toc(html_body)
+      nav = +"    <ol>\n"
+      open_h2 = open_h3 = false
+      html_body.scan(%r{<h([23])\s+id="([^"]+)"[^>]*>(.*?)</h\1>}m).each do |level, id, label|
+        text = label.gsub(/<[^>]+>/, '').strip
+        if level == '2'
+          nav << "        </ol>\n" if open_h3
+          nav << "      </li>\n"   if open_h2
+          nav << %(      <li><a href="##{id}">#{text}</a>)
+          open_h2 = true
+          open_h3 = false
+        else
+          unless open_h3
+            nav << "\n        <ol>\n"
+            open_h3 = true
+          end
+          nav << %(          <li><a href="##{id}">#{text}</a></li>\n)
+        end
+      end
+      nav << "        </ol>\n" if open_h3
+      nav << "      </li>\n"   if open_h2
+      nav << "    </ol>\n"
+      nav
+    end
+
+    # Tiny ERB context to expose the locals as methods.
+    class SidebarContext
+      def initialize(cv_pdf_url:, resume_pdf_url:, toc_html:)
+        @cv_pdf_url     = cv_pdf_url
+        @resume_pdf_url = resume_pdf_url
+        @toc_html       = toc_html
+      end
+      attr_reader :cv_pdf_url, :resume_pdf_url, :toc_html
+      def get_binding; binding; end
+    end
+
+    private_class_method def self.read_rendered_body
+      require 'kramdown'
+      require 'kramdown-parser-gfm'
+      md = File.read(CV::Markdown::DEFAULT_OUTPUT, encoding: 'UTF-8')
+      md = md.sub(/\A---\n.*?\n---\n+/m, '')
+      ::Kramdown::Document.new(
+        md,
+        input: 'GFM', auto_ids: true,
+        smart_quotes: %w[apos rsquo apos rsquo]
+      ).to_html
+    end
+  end
+end

--- a/templates/markdown/cv-theme.js
+++ b/templates/markdown/cv-theme.js
@@ -1,0 +1,57 @@
+// Dark/light toggle for the CV. Initialises from localStorage if set,
+// otherwise from the OS preference, and persists the choice. Also fires
+// before the layout paints so we don't get a flash of the wrong theme.
+//
+// Lives on `.cv-layout` rather than <html> so the same script works
+// whether the CV is the whole page (standalone preview) or embedded
+// inside another site that has its own theming.
+(function () {
+  var STORAGE_KEY = 'cv-theme';
+
+  function layouts() {
+    return document.querySelectorAll('.cv-layout');
+  }
+
+  function apply(theme) {
+    layouts().forEach(function (el) { el.dataset.theme = theme; });
+    document.querySelectorAll('[data-cv-theme-toggle]').forEach(function (btn) {
+      var label = btn.querySelector('.cv-theme-label');
+      var icon  = btn.querySelector('.cv-theme-icon');
+      if (label) label.textContent = theme === 'dark' ? 'Dark' : 'Light';
+      if (icon)  icon.textContent  = theme === 'dark' ? '☾' : '☀';
+      btn.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
+    });
+  }
+
+  function preferredTheme() {
+    try {
+      var stored = localStorage.getItem(STORAGE_KEY);
+      if (stored === 'dark' || stored === 'light') return stored;
+    } catch (_) { /* localStorage may be disabled */ }
+    return window.matchMedia &&
+           window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark' : 'light';
+  }
+
+  // Apply early to avoid a flash on first paint.
+  apply(preferredTheme());
+
+  function init() {
+    apply(preferredTheme());
+    document.querySelectorAll('[data-cv-theme-toggle]').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var els = layouts();
+        var cur = els.length && els[0].dataset.theme === 'dark' ? 'dark' : 'light';
+        var next = cur === 'dark' ? 'light' : 'dark';
+        apply(next);
+        try { localStorage.setItem(STORAGE_KEY, next); } catch (_) {}
+      });
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/templates/markdown/cv.md.erb
+++ b/templates/markdown/cv.md.erb
@@ -5,6 +5,7 @@
     Note on the `{:.entry}` IAL: kramdown attaches the class to the
     preceding paragraph; preview.css and the deployed Jekyll layout target
     `.entry` to make role/title lines visually distinct from the body. -%>
+<%- show_header = defined?(page_header) ? page_header : true -%>
 <%- if jekyll_front_matter -%>
 ---
 layout: cv
@@ -13,6 +14,7 @@ subtitle: <%= h(data.basics['title']) %>
 permalink: /cv/
 ---
 <% end -%>
+<%- if show_header -%>
 
 # <%= h(data.basics['name']) %>
 
@@ -33,6 +35,7 @@ permalink: /cv/
 <% end %>
 
 ---
+<%- end -%>
 
 ## Education
 

--- a/templates/markdown/preview.css
+++ b/templates/markdown/preview.css
@@ -1,156 +1,297 @@
-/* Preview-only CSS for `make preview`. Production styling lives in the
-   target Jekyll site (cycomachead.github.io/cv/) — this is just enough to
-   read the rendered Markdown locally. */
+/* Styling for the rendered CV. Used in two places:
+   1. The standalone preview shell (`make preview`) — inlined into cv.html.
+   2. The deployed Jekyll site — shipped as cv.css alongside cv-sidebar.html
+      and the rendered Markdown body, so the milo-default page can drop the
+      CV into its existing layout without fighting site CSS.
 
-:root {
-  --berkeley-blue:      #002676;
-  --berkeley-blue-soft: #5b6da3;
-  --pacific:            #46535e;
-  --rule:               #e5e7eb;
-  --text:               #111827;
-  --bg:                 #ffffff;
-  --sidebar-bg:         #fafaf7;
-  --content-max:        46rem;
-  --sidebar-width:      18rem;
-}
+   Everything is scoped to `.cv-layout` for that reason. The theme is light by
+   default; setting `data-theme="dark"` on `.cv-layout` (done by the toggle
+   script in the sidebar) flips to the Berkeley-blue-light palette. */
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --text: #e5e7eb; --bg: #0f1115;
-    --sidebar-bg: #161922;
-    --rule: #2b3340; --pacific: #9ca3af;
-    --berkeley-blue: #79a8ff; --berkeley-blue-soft: #5b88d6;
-  }
-}
+.cv-layout {
+  --cv-berkeley-blue:       #002676;
+  --cv-berkeley-blue-dark:  #001a52;
+  --cv-berkeley-blue-light: #79a8ff;
+  --cv-pacific:             #46535e;
+  --cv-rule:                #e5e7eb;
+  --cv-text:                #111827;
+  --cv-text-muted:          #46535e;
+  --cv-bg:                  #ffffff;
+  --cv-sidebar-bg:          #f5f6f8;
+  --cv-accent:              var(--cv-berkeley-blue);
+  --cv-accent-hover:        var(--cv-berkeley-blue-dark);
+  --cv-button-text:         #ffffff;
 
-* { box-sizing: border-box; }
+  --cv-content-max:  46rem;
+  --cv-sidebar-w:    18rem;
 
-body {
-  margin: 0;
-  background: var(--bg);
-  color: var(--text);
+  background: var(--cv-bg);
+  color:      var(--cv-text);
   font-family: -apple-system, BlinkMacSystemFont, "Source Sans Pro",
                "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  font-size: 17px;
+  font-size:   17px;
   line-height: 1.55;
+}
+
+.cv-layout[data-theme="dark"] {
+  --cv-rule:           #2b3340;
+  --cv-text:           #e5e7eb;
+  --cv-text-muted:     #9aa3ad;
+  --cv-bg:             #0f1320;
+  --cv-sidebar-bg:     #161b2a;
+  --cv-pacific:        #9aa3ad;
+  --cv-accent:         var(--cv-berkeley-blue-light);
+  --cv-accent-hover:   #a4c2ff;
+  --cv-button-text:    #0f1320;
+}
+
+.cv-layout *,
+.cv-layout *::before,
+.cv-layout *::after { box-sizing: border-box; }
+
+/* Ensure the standalone preview page also picks up the bg color so the
+   margins around the layout don't look stranded. Targets the document
+   only when our layout is mounted as the page itself. */
+html:has(> body > .cv-layout),
+body:has(> .cv-layout) {
+  margin: 0;
+  background: var(--cv-bg, #fff);
 }
 
 /* ---------------- Layout: sidebar + content ---------------- */
 
-.layout {
+.cv-layout {
   display: grid;
-  grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+  grid-template-columns: var(--cv-sidebar-w) minmax(0, 1fr);
   gap: 0;
   min-height: 100vh;
 }
 
-.sidebar {
+.cv-sidebar {
   position: sticky;
   top: 0;
   align-self: start;
   height: 100vh;
   overflow-y: auto;
-  padding: 2rem 1.25rem 2rem 2rem;
-  background: var(--sidebar-bg);
-  border-right: 1px solid var(--rule);
+  padding: 1.75rem 1.25rem 2rem 1.75rem;
+  background: var(--cv-sidebar-bg);
+  border-right: 1px solid var(--cv-rule);
   font-size: 0.92rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 }
 
-.content {
-  max-width: var(--content-max);
+.cv-content {
+  max-width: var(--cv-content-max);
   margin: 0 auto;
   padding: 3rem clamp(1rem, 4vw, 2rem) 5rem;
 }
 
 @media (max-width: 800px) {
-  .layout { grid-template-columns: 1fr; }
-  .sidebar {
+  .cv-layout { grid-template-columns: 1fr; }
+  .cv-sidebar {
     position: static;
     height: auto;
     border-right: none;
-    border-bottom: 1px solid var(--rule);
-    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--cv-rule);
+    padding: 1.25rem;
   }
-  .sidebar .toc > ol > li > ol { display: none; } /* hide h3s on small screens */
+  /* Hide h3 entries in the TOC when the sidebar is collapsed at the top. */
+  .cv-sidebar .cv-toc > ol > li > ol { display: none; }
 }
 
-/* ---------------- Sidebar TOC ---------------- */
+/* ---------------- Sidebar: download buttons ---------------- */
 
-.toc ol {
+.cv-downloads {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.cv-btn {
+  display: inline-block;
+  text-align: center;
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-weight: 600;
+  letter-spacing: 0.005em;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.cv-btn-primary {
+  background: var(--cv-accent);
+  color: var(--cv-button-text);
+  padding: 0.65rem 1rem;
+  font-size: 1rem;
+}
+
+.cv-btn-primary:hover,
+.cv-btn-primary:focus-visible {
+  background: var(--cv-accent-hover);
+  color: var(--cv-button-text);
+}
+
+.cv-btn-secondary {
+  background: transparent;
+  color: var(--cv-accent);
+  border-color: var(--cv-rule);
+  padding: 0.45rem 0.85rem;
+  font-size: 0.9rem;
+}
+
+.cv-btn-secondary:hover,
+.cv-btn-secondary:focus-visible {
+  border-color: var(--cv-accent);
+  color: var(--cv-accent-hover);
+}
+
+/* ---------------- Sidebar: theme toggle ---------------- */
+
+.cv-theme-toggle {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--cv-text-muted);
+  padding-top: 1rem;
+  border-top: 1px solid var(--cv-rule);
+}
+
+.cv-theme-toggle button {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--cv-rule);
+  border-radius: 999px;
+  padding: 0.3rem 0.7rem;
+  font: inherit;
+  color: var(--cv-text);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.cv-theme-toggle button:hover,
+.cv-theme-toggle button:focus-visible {
+  border-color: var(--cv-accent);
+  color: var(--cv-accent);
+}
+
+.cv-theme-toggle .cv-theme-icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+/* ---------------- Sidebar: TOC ---------------- */
+
+.cv-toc {
+  font-size: 0.92rem;
+}
+
+.cv-toc-heading {
+  margin: 0 0 0.5rem;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--cv-text-muted);
+  font-weight: 600;
+}
+
+.cv-toc ol {
   list-style: none;
   padding: 0;
   margin: 0;
 }
-.toc > ol > li {
-  margin: 0.6rem 0;
+.cv-toc > ol > li {
+  margin: 0.55rem 0;
 }
-.toc > ol > li > a {
+.cv-toc > ol > li > a {
   font-weight: 600;
-  color: var(--berkeley-blue);
+  color: var(--cv-accent);
 }
-.toc > ol > li > ol {
+.cv-toc > ol > li > ol {
   margin: 0.25rem 0 0 0.85rem;
   padding-left: 0.5rem;
-  border-left: 1px solid var(--rule);
+  border-left: 1px solid var(--cv-rule);
 }
-.toc > ol > li > ol li {
+.cv-toc > ol > li > ol li {
   margin: 0.15rem 0;
 }
-.toc > ol > li > ol a {
-  color: var(--pacific);
+.cv-toc > ol > li > ol a {
+  color: var(--cv-pacific);
   font-size: 0.88rem;
 }
 
-/* ---------------- Headings ---------------- */
-
-h1, h2, h3 {
-  color: var(--berkeley-blue);
-  line-height: 1.2;
-}
-h1 { font-size: 2.25rem; margin: 0 0 0.25rem; letter-spacing: -0.01em; }
-h2 {
-  font-size: 1.5rem;
-  margin: 3rem 0 0.6rem;
-  padding-bottom: 0.25rem;
-  border-bottom: 2px solid var(--berkeley-blue);
-}
-h3 { font-size: 1.05rem; margin: 1.6rem 0 0.4rem; color: var(--pacific); }
-
-a {
-  color: var(--berkeley-blue);
+.cv-toc a {
   text-decoration: none;
   border-bottom: 1px solid transparent;
 }
-a:hover { border-bottom-color: var(--berkeley-blue); }
+.cv-toc a:hover { border-bottom-color: currentColor; }
 
-hr { border: 0; border-top: 1px solid var(--rule); margin: 1.5rem 0; }
+/* ---------------- Headings ---------------- */
 
-ol, ul { padding-left: 1.4rem; }
-li + li { margin-top: 0.25rem; }
+.cv-content h1,
+.cv-content h2,
+.cv-content h3 {
+  color: var(--cv-accent);
+  line-height: 1.2;
+}
+.cv-content h1 {
+  font-size: 2.25rem;
+  margin: 0 0 0.25rem;
+  letter-spacing: -0.01em;
+}
+.cv-content h2 {
+  font-size: 1.5rem;
+  margin: 3rem 0 0.6rem;
+  padding-bottom: 0.25rem;
+  border-bottom: 2px solid var(--cv-accent);
+}
+.cv-content h3 {
+  font-size: 1.05rem;
+  margin: 1.6rem 0 0.4rem;
+  color: var(--cv-pacific);
+}
 
-blockquote {
-  border-left: 3px solid var(--rule);
+.cv-content a {
+  color: var(--cv-accent);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+}
+.cv-content a:hover { border-bottom-color: var(--cv-accent); }
+
+.cv-content hr { border: 0; border-top: 1px solid var(--cv-rule); margin: 1.5rem 0; }
+
+.cv-content ol, .cv-content ul { padding-left: 1.4rem; }
+.cv-content li + li { margin-top: 0.25rem; }
+
+.cv-content blockquote {
+  border-left: 3px solid var(--cv-rule);
   margin: 0.5rem 0;
   padding: 0.1rem 0.9rem;
-  color: var(--pacific);
+  color: var(--cv-pacific);
   font-size: 0.95rem;
 }
 
-p { margin: 0.4rem 0; }
-em { font-style: italic; }
-strong { font-weight: 600; }
+.cv-content p { margin: 0.4rem 0; }
+.cv-content em { font-style: italic; }
+.cv-content strong { font-weight: 600; }
 
-/* ---------------- Top-of-page ---------------- */
+/* ---------------- Top-of-page (only when page_header is on) ---------------- */
 
-.contact {
+.cv-content .contact {
   margin: 0.5rem 0 0;
-  color: var(--pacific);
+  color: var(--cv-pacific);
   font-size: 0.95rem;
 }
-.bio {
+.cv-content .bio {
   margin: 1.5rem 0 0;
   font-size: 1.05rem;
-  color: var(--text);
+  color: var(--cv-text);
 }
 
 /* ---------------- Entry titles ---------------- */
@@ -159,12 +300,12 @@ strong { font-weight: 600; }
    touch more size, and breathing room above. The trailing entry margin is
    the bigger lever — it's much easier to scan with extra space below. */
 
-.entry {
+.cv-content .entry {
   margin: 1.5rem 0 0.3rem;
   line-height: 1.35;
 }
-.entry strong:first-child {
-  color: var(--berkeley-blue);
+.cv-content .entry strong:first-child {
+  color: var(--cv-accent);
   font-size: 1.06rem;
   letter-spacing: 0.005em;
 }
@@ -172,12 +313,8 @@ strong { font-weight: 600; }
 /* The text after the entry header line (employer, location, summary) is
    inside the same paragraph because of GFM soft breaks. Display it on its
    own line via the `<br>` kramdown emits, but mute the color slightly. */
-.entry br + * { color: var(--pacific); }
+.cv-content .entry br + * { color: var(--cv-pacific); }
 
 /* ---------------- Reversed publication lists ---------------- */
-ol[reversed] {
-  list-style: decimal;
-}
-ol[reversed] li {
-  margin-bottom: 0.6rem;
-}
+.cv-content ol[reversed] { list-style: decimal; }
+.cv-content ol[reversed] li { margin-bottom: 0.6rem; }

--- a/templates/markdown/preview.html.erb
+++ b/templates/markdown/preview.html.erb
@@ -9,13 +9,14 @@
   </style>
 </head>
 <body>
-  <div class="layout">
-    <aside class="sidebar">
+  <div class="cv-layout">
 {{SIDEBAR}}
-    </aside>
-    <main class="content">
+    <main class="cv-content">
 {{BODY}}
     </main>
   </div>
+  <script>
+{{SCRIPT}}
+  </script>
 </body>
 </html>

--- a/templates/markdown/sidebar.html.erb
+++ b/templates/markdown/sidebar.html.erb
@@ -1,0 +1,35 @@
+<%# Sidebar fragment shared by:
+    - the standalone preview (templates/markdown/preview.html.erb)
+    - the cv-sidebar.html artifact shipped to the Jekyll deploy
+
+    Locals:
+      cv_pdf_url     URL for the full CV PDF (default: cv.pdf)
+      resume_pdf_url URL for the one-page resume PDF (default: resume.pdf)
+      toc_html       pre-rendered <ol>...</ol> markup for the section TOC
+-%>
+<aside class="cv-sidebar">
+  <div class="cv-downloads">
+    <a class="cv-btn cv-btn-primary" href="<%= cv_pdf_url %>" download>
+      Download CV (PDF)
+    </a>
+    <a class="cv-btn cv-btn-secondary" href="<%= resume_pdf_url %>" download>
+      Download résumé (1 page)
+    </a>
+  </div>
+
+  <nav class="cv-toc" aria-label="Section navigation">
+    <p class="cv-toc-heading">Sections</p>
+<%= toc_html %>
+  </nav>
+
+  <div class="cv-theme-toggle">
+    <span>Theme</span>
+    <button type="button"
+            data-cv-theme-toggle
+            aria-pressed="false"
+            aria-label="Toggle dark mode">
+      <span class="cv-theme-icon" aria-hidden="true">☀</span>
+      <span class="cv-theme-label">Light</span>
+    </button>
+  </div>
+</aside>

--- a/test/test_markdown.rb
+++ b/test/test_markdown.rb
@@ -52,10 +52,25 @@ class MarkdownBuildTest < Minitest::Test
       assert_includes html, '<h1 id="michael-ball">Michael Ball</h1>'
       assert_includes html, 'Snap<em>!</em>'
 
-      # Sidebar TOC was generated and has h2 entries plus at least one h3.
-      assert_includes html, 'class="toc"'
+      # Layout wrapper is present so the dark-mode toggle (via data-theme on
+      # .cv-layout) and the scoped CSS find their root.
+      assert_includes html, 'class="cv-layout"'
+
+      # Sidebar contains downloads, TOC, theme toggle.
+      assert_includes html, 'class="cv-sidebar"'
+      assert_includes html, 'class="cv-downloads"'
+      assert_includes html, 'cv-btn cv-btn-primary'
+      assert_includes html, 'Download CV (PDF)'
+      assert_includes html, 'cv-btn cv-btn-secondary'
+      assert_includes html, '1 page'
+      assert_includes html, 'class="cv-toc"'
+      assert_includes html, 'data-cv-theme-toggle'
       assert_includes html, 'href="#education"'
       assert_includes html, 'href="#course-descriptions"'
+
+      # Theme toggle script is inlined.
+      assert_includes html, "STORAGE_KEY = 'cv-theme'"
+      assert_includes html, 'data-cv-theme-toggle'
 
       # Entry paragraphs got the .entry class via the kramdown IAL.
       assert_includes html, 'class="entry"'
@@ -63,5 +78,59 @@ class MarkdownBuildTest < Minitest::Test
       # Front matter was stripped.
       refute_match(/\A<!DOCTYPE html.*\n---\n/, html)
     end
+  end
+
+  def test_md_embed_strips_page_header_but_keeps_front_matter
+    Dir.mktmpdir do |dir|
+      out = CV::Markdown.build_embed(output: File.join(dir, 'cv-embed.md'))
+      md  = File.read(out, encoding: 'UTF-8')
+
+      assert_match(/\A---\nlayout: cv\n/, md,
+                   'jekyll front matter is preserved')
+      refute_includes md, '# Michael Ball'
+      refute_includes md, '{:.contact}'
+      refute_includes md, '{:.bio}'
+
+      # Body content is still there.
+      assert_includes md, '## Education'
+      assert_includes md, '## Positions'
+    end
+  end
+
+  def test_sidebar_fragment_has_downloads_toc_toggle
+    Dir.mktmpdir do |dir|
+      CV::Markdown.build(output: File.join(dir, 'cv.md'))
+      # Hand the sidebar a tiny rendered body so we don't depend on the full
+      # markdown→html round-trip for this test.
+      body = <<~HTML
+        <h2 id="education">Education</h2>
+        <h3 id="degree">Degree</h3>
+        <h2 id="positions">Positions</h2>
+      HTML
+      out = CV::Sidebar.build(output: File.join(dir, 'cv-sidebar.html'),
+                              html_body: body)
+      html = File.read(out, encoding: 'UTF-8')
+
+      assert_includes html, 'class="cv-sidebar"'
+      assert_includes html, 'class="cv-btn cv-btn-primary"'
+      assert_includes html, 'href="cv.pdf"'
+      assert_includes html, 'href="resume.pdf"'
+      assert_includes html, 'href="#education"'
+      assert_includes html, 'href="#degree"'
+      assert_includes html, 'href="#positions"'
+      assert_includes html, 'data-cv-theme-toggle'
+      # No <html>/<body> wrapper — this is a fragment to be included.
+      refute_includes html, '<html'
+      refute_includes html, '<body'
+    end
+  end
+
+  def test_sidebar_accepts_custom_pdf_urls
+    body = '<h2 id="x">X</h2>'
+    html = CV::Sidebar.render(html_body: body,
+                              cv_pdf_url: '/cv-full.pdf',
+                              resume_pdf_url: '/one-page.pdf')
+    assert_includes html, 'href="/cv-full.pdf"'
+    assert_includes html, 'href="/one-page.pdf"'
   end
 end


### PR DESCRIPTION
## Implement embedded CV sidebar with dark mode and download buttons

Adds a sidebar-embedded CV view suitable for both standalone preview and Jekyll site integration, with Berkeley blue theming, a persistent dark mode toggle, and download buttons for the full CV and one-page résumé PDFs.

## Changes

**New artifacts shipped to the Jekyll deploy:**
- `cv-embed.md` — header-stripped Markdown body (no name/title/contact block; the site layout supplies its own page title)
- `cv-sidebar.html` — self-contained sidebar fragment with download buttons, section TOC, and theme toggle; drop into `_includes/` and use `{% include cv-sidebar.html %}`
- `cv.css` — all rules scoped to `.cv-layout` to prevent style leakage in the host Jekyll site
- `cv-theme.js` — dark/light toggle that persists to `localStorage` and falls back to OS preference

**Core changes:**
- `lib/cv/sidebar.rb` (new) — extracts TOC from rendered HTML body and renders the sidebar fragment via ERB; used by both `Preview.build` and the new `bin/cv sidebar` command
- `templates/markdown/sidebar.html.erb` (new) — shared sidebar template (download buttons + TOC + toggle)
- `templates/markdown/cv-theme.js` (new) — theme toggle script; sets `data-theme` on `.cv-layout`, fires before first paint to avoid flash
- `templates/markdown/preview.css` — rewritten with Berkeley blue accents, light-by-default, dark mode via `.cv-layout[data-theme="dark"]`, all selectors scoped to `.cv-layout`
- `lib/cv/markdown.rb` — adds `build_embed` (keeps front matter, drops in-page header); `page_header` flag added to `build`
- `lib/cv/preview.rb` — delegates sidebar rendering to `CV::Sidebar`, inlines `cv-theme.js`
- `bin/cv`, `Rakefile`, `Makefile` — adds `md:embed`, `sidebar`, and `embed` commands/targets; `deploy-out` stages all new artifacts
- `.github/workflows/deploy.yml` — runs `rake site:embed` and ships the new files to `cycomachead.github.io/cv/`

**Jekyll integration:** wrap content in `.cv-layout`, include `cv-sidebar.html`, and load `cv.css`/`cv-theme.js`. Whether this sits alongside or replaces the existing `milo-default` right sidebar is a Jekyll-side decision — the artifacts don't constrain it.

**Tests:** added coverage for `build_embed` (strips header, keeps front matter), `Sidebar.build` (downloads, TOC, toggle markup), `Sidebar.render` (custom PDF URLs), and the preview's new `.cv-layout`/`.cv-sidebar` structure.

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/jHzqgPtcfNt6/implementations/R9kbHLhGCLNB) | [Guided Review](https://www.superconductor.com/tickets/jHzqgPtcfNt6/implementations/R9kbHLhGCLNB?tab=guided_review)

<!-- created-by-superconductor -->