### PR TITLE
Fix PDF build failure due to missing fonts-sourcecodepro package

### DIFF
--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -18,13 +18,14 @@ jobs:
       - uses: actions/checkout@v4
 
       # main.tex uses \usepackage{fontspec} + Source Sans Pro, which requires
-      # lualatex (or xelatex).
+      # lualatex (or xelatex). The fonts ship with TeX Live itself (the
+      # sourcesanspro package), so no extra system font packages are needed —
+      # the Debian-style fonts-* names don't exist in the action's Alpine image.
       - name: Build full CV (main.tex)
         uses: xu-cheng/latex-action@v3
         with:
           root_file: main.tex
           latexmk_use_lualatex: true
-          extra_system_packages: "fonts-sourcecodepro fonts-sourcesanspro"
 
       - name: Build one-page resume
         uses: xu-cheng/latex-action@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,12 +17,14 @@ jobs:
       - uses: actions/checkout@v4
 
       # ---------- 1. Build PDFs from LaTeX ----------
+      # Source Sans Pro ships with TeX Live itself (the sourcesanspro
+      # package), so no extra system font packages are needed — the
+      # Debian-style fonts-* names don't exist in the action's Alpine image.
       - name: Build full CV (main.tex)
         uses: xu-cheng/latex-action@v3
         with:
           root_file: main.tex
           latexmk_use_lualatex: true
-          extra_system_packages: "fonts-sourcecodepro fonts-sourcesanspro"
 
       - name: Build one-page resume
         uses: xu-cheng/latex-action@v3
@@ -36,7 +38,6 @@ jobs:
         with:
           root_file: public.tex
           latexmk_use_lualatex: true
-          extra_system_packages: "fonts-sourcecodepro fonts-sourcesanspro"
 
       # ---------- 2. Build cv.md from YAML+bib ----------
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Fix PDF build failure caused by invalid system font packages

The PDF build was failing because `extra_system_packages` specified Debian-style `fonts-*` package names, but the `xu-cheng/latex-action` image is Alpine-based and has no such packages. These packages were also unnecessary — Source Sans Pro is already bundled with TeX Live via the `sourcesanspro` package, and Source Code Pro isn't used in the project.

## Changes

- Removed `extra_system_packages: "fonts-sourcecodepro fonts-sourcesanspro"` from the `main.tex` build step in `build-cv.yml`
- Removed the same line from both the `main.tex` and `public.tex` build steps in `deploy.yml`
- Updated comments in both workflow files to clarify that Source Sans Pro is resolved through TeX Live, and that Debian-style `fonts-*` packages don't exist in the Alpine-based action image

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/Mq9zgGzq6h7J/implementations/h6LjpcNQgPRT) | [Guided Review](https://www.superconductor.com/tickets/Mq9zgGzq6h7J/implementations/h6LjpcNQgPRT?tab=guided_review)

<!-- created-by-superconductor -->